### PR TITLE
Fix for newer PHP versions

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -210,8 +210,9 @@ JSFN;
      * output appropriate html
      */
     function html() {
-     $this->macros_data = $this->get_macros();
-     $this->js();
+      global $ID;
+      $this->macros_data = $this->get_macros();
+      $this->js();
       if($this->output) {
         ptln('<pre>' . $this->output . '</pre>');
       }


### PR DESCRIPTION
On PHP 8, $ID is not accessible unless specifically declared as a global. The way this manifests is that none of the "save" actions on the admin area editor form work due to an empty form target. One line fix (plus light indentation cleanup).